### PR TITLE
Fixed merge command to show proper information after merge

### DIFF
--- a/src/Command/MergeCommand.php
+++ b/src/Command/MergeCommand.php
@@ -85,13 +85,10 @@ class MergeCommand extends GitHubBaseCommand
             array('prType' => $prType, 'pr' => $pr, 'commits' => $commits)
         );
 
-
-        $gitHelper->mergeRemote($input->getOption('username'), 'master', $input->getArgument('pr'), $commitMessage);
-
-        $pr = $client->pullRequest()->show($input->getOption('username'), $input->getOption('repository'), $input->getArgument('pr'));
+        $merged = $gitHelper->mergeRemote($input->getOption('username'), 'master', $input->getArgument('pr'), $commitMessage);
 
         // check if the PR has been merged
-        if (false === $pr['merged']) {
+        if (false === $merged) {
             $output->writeln('<error>The pull request could not be merged.</error>');
             return;
         }

--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -43,10 +43,11 @@ class GitHelper extends Helper
     /**
      * Executes a remote merge
      *
-     * @param string  $username
-     * @param string  $targetBranch
+     * @param string $username
+     * @param string $targetBranch
      * @param integer $pullRequest
-     * @param string  $message
+     * @param string $message
+     * @return bool true if all commands have been executed successfully
      */
     public function mergeRemote($username, $targetBranch, $pullRequest, $message)
     {
@@ -98,7 +99,8 @@ class GitHelper extends Helper
             # restore the stashes
             $recoveryCommands[] = sprintf('git stash pop', $previousBranch);
         }
-        $processHelper->runProcesses($commands, $recoveryCommands);
+
+        return $processHelper->runProcesses($commands, $recoveryCommands);
     }
 
     /**

--- a/src/Helper/ProcessHelper.php
+++ b/src/Helper/ProcessHelper.php
@@ -32,6 +32,7 @@ class ProcessHelper extends Helper
      *
      * @param array $commands
      * @param array $recoveryCommands
+     * @return bool false if an error occurred otherwise true - errors in the recovery commands will not be watched
      */
     public function runProcesses(array $commands, array $recoveryCommands = [])
     {
@@ -45,12 +46,15 @@ class ProcessHelper extends Helper
         }
 
         if (false === $commandError) {
-            return;
+            return true;
         }
 
+        // errors in the recovery mode will be ignored
         foreach($recoveryCommands as $command) {
             $this->runProcess($command);
         }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
The merge command had an issue detecting the merge status since it relied on another
call to the github api. Most likely to the way we merge the commits the merge status is
updated slightly later.

The check now relies on the fact that all commands will be executed successfully.

Tickets:
- none
