### PR TITLE
Support different target branches and automatically rebase before merge

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5,6 +5,7 @@
         "This file is @generated automatically"
     ],
     "hash": "98c2c03fdf8414bc352ac46c6de4e3cc",
+    "content-hash": "5109c5651dbc80c56bd463b152392ee9",
     "packages": [
         {
             "name": "guzzle/guzzle",
@@ -103,16 +104,16 @@
         },
         {
             "name": "knplabs/github-api",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/KnpLabs/php-github-api.git",
-                "reference": "313d7ed61494f525ab93cfd8595ec2d398533220"
+                "reference": "832b7be695ed2733741cd5c79166b4a88fb50786"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/KnpLabs/php-github-api/zipball/313d7ed61494f525ab93cfd8595ec2d398533220",
-                "reference": "313d7ed61494f525ab93cfd8595ec2d398533220",
+                "url": "https://api.github.com/repos/KnpLabs/php-github-api/zipball/832b7be695ed2733741cd5c79166b4a88fb50786",
+                "reference": "832b7be695ed2733741cd5c79166b4a88fb50786",
                 "shasum": ""
             },
             "require": {
@@ -160,20 +161,20 @@
                 "gist",
                 "github"
             ],
-            "time": "2015-08-20 09:44:33"
+            "time": "2015-10-11 02:38:28"
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.4",
+            "version": "v2.7.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Console.git",
-                "reference": "9ff9032151186bd66ecee727d728f1319f52d1d8"
+                "url": "https://github.com/symfony/console.git",
+                "reference": "06cb17c013a82f94a3d840682b49425cd00a2161"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/9ff9032151186bd66ecee727d728f1319f52d1d8",
-                "reference": "9ff9032151186bd66ecee727d728f1319f52d1d8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/06cb17c013a82f94a3d840682b49425cd00a2161",
+                "reference": "06cb17c013a82f94a3d840682b49425cd00a2161",
                 "shasum": ""
             },
             "require": {
@@ -217,20 +218,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-09-03 11:40:38"
+            "time": "2015-09-25 08:32:23"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.4",
+            "version": "v2.7.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "b58c916f1db03a611b72dd702564f30ad8fe83fa"
+                "url": "https://github.com/symfony/event-dispatcher.git",
+                "reference": "ae4dcc2a8d3de98bd794167a3ccda1311597c5d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/b58c916f1db03a611b72dd702564f30ad8fe83fa",
-                "reference": "b58c916f1db03a611b72dd702564f30ad8fe83fa",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/ae4dcc2a8d3de98bd794167a3ccda1311597c5d9",
+                "reference": "ae4dcc2a8d3de98bd794167a3ccda1311597c5d9",
                 "shasum": ""
             },
             "require": {
@@ -275,20 +276,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-24 07:13:45"
+            "time": "2015-09-22 13:49:29"
         },
         {
             "name": "symfony/process",
-            "version": "v2.7.4",
+            "version": "v2.7.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Process.git",
-                "reference": "f7b3f73f70a7f8f49a1c838dc3debbf054732d8e"
+                "url": "https://github.com/symfony/process.git",
+                "reference": "b27c8e317922cd3cdd3600850273cf6b82b2e8e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Process/zipball/f7b3f73f70a7f8f49a1c838dc3debbf054732d8e",
-                "reference": "f7b3f73f70a7f8f49a1c838dc3debbf054732d8e",
+                "url": "https://api.github.com/repos/symfony/process/zipball/b27c8e317922cd3cdd3600850273cf6b82b2e8e9",
+                "reference": "b27c8e317922cd3cdd3600850273cf6b82b2e8e9",
                 "shasum": ""
             },
             "require": {
@@ -324,20 +325,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-27 06:45:45"
+            "time": "2015-09-19 19:59:23"
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.7.4",
+            "version": "v2.7.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Yaml.git",
-                "reference": "2dc7b06c065df96cc686c66da2705e5e18aef661"
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/2dc7b06c065df96cc686c66da2705e5e18aef661",
-                "reference": "2dc7b06c065df96cc686c66da2705e5e18aef661",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
+                "reference": "31cb2ad0155c95b88ee55fe12bc7ff92232c1770",
                 "shasum": ""
             },
             "require": {
@@ -373,20 +374,20 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-24 07:13:45"
+            "time": "2015-09-14 14:14:09"
         },
         {
             "name": "twig/twig",
-            "version": "v1.22.1",
+            "version": "v1.22.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "b7fc2469fa009897871fb95b68237286fc54a5ad"
+                "reference": "ebfc36b7e77b0c1175afe30459cf943010245540"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/b7fc2469fa009897871fb95b68237286fc54a5ad",
-                "reference": "b7fc2469fa009897871fb95b68237286fc54a5ad",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/ebfc36b7e77b0c1175afe30459cf943010245540",
+                "reference": "ebfc36b7e77b0c1175afe30459cf943010245540",
                 "shasum": ""
             },
             "require": {
@@ -434,7 +435,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2015-09-15 06:50:16"
+            "time": "2015-10-13 07:07:02"
         }
     ],
     "packages-dev": [],

--- a/src/Command/MergeCommand.php
+++ b/src/Command/MergeCommand.php
@@ -24,7 +24,7 @@ class MergeCommand extends GitHubBaseCommand
             ->setDescription('Merges the pull request given')
             ->addArgument('pr', InputArgument::REQUIRED, 'Pull Request number')
             ->addOption('force', null, InputOption::VALUE_NONE, 'Enforce the merge if PR is in unstable state')
-        ;
+            ->addOption('branch', null, InputOption::VALUE_REQUIRED, 'Target branch', 'master');
 
         parent::configure();
     }
@@ -39,6 +39,8 @@ class MergeCommand extends GitHubBaseCommand
 
         /** @var QuestionHelper $questionHelper */
         $questionHelper = $this->getHelper('question');
+
+        $branch = $input->getOption('branch');
 
         // fetch the PR information
         $client = $this->getClient();
@@ -65,7 +67,7 @@ class MergeCommand extends GitHubBaseCommand
         );
 
         $prType = $questionHelper->ask($input, $output, $question);
-        $question = new ConfirmationQuestion(sprintf('Merge <info>%s</info> PR <info>#%s</info> "<info>%s</info>" by <info>%s</info>? [y/n] ', $prType, $pr['number'], $pr['title'], $pr['user']['login']), false);
+        $question = new ConfirmationQuestion(sprintf('Merge <info>%s</info> PR <info>#%s</info> "<info>%s</info>" by <info>%s</info> into <info>(%s)</info>? [y/n] ', $prType, $pr['number'], $pr['title'], $pr['user']['login'], $branch), false);
 
         if (!$questionHelper->ask($input, $output, $question)) {
             return;
@@ -85,7 +87,7 @@ class MergeCommand extends GitHubBaseCommand
             array('prType' => $prType, 'pr' => $pr, 'commits' => $commits)
         );
 
-        $merged = $gitHelper->mergeRemote($input->getOption('username'), 'master', $input->getArgument('pr'), $commitMessage);
+        $merged = $gitHelper->mergeRemote($input->getOption('username'), $branch, $input->getArgument('pr'), $commitMessage);
 
         // check if the PR has been merged
         if (false === $merged) {

--- a/src/Helper/GitHelper.php
+++ b/src/Helper/GitHelper.php
@@ -43,10 +43,10 @@ class GitHelper extends Helper
     /**
      * Executes a remote merge
      *
-     * @param string $username
-     * @param string $targetBranch
+     * @param string  $username
+     * @param string  $targetBranch
      * @param integer $pullRequest
-     * @param string $message
+     * @param string  $message
      * @return bool true if all commands have been executed successfully
      */
     public function mergeRemote($username, $targetBranch, $pullRequest, $message)
@@ -67,6 +67,15 @@ class GitHelper extends Helper
 
         # checkout the current state of the remote repository
         $commands[] = sprintf('git checkout %s/%s -b tmp_%s', $username, $targetBranch, $targetBranch);
+
+        # checkout the pr branch
+        $commands[] = sprintf('git checkout pr_%d', $pullRequest);
+
+        # rebase the commits
+        $commands[] = sprintf('git rebase tmp_%s', $targetBranch);
+
+        # switch back to the target branch
+        $commands[] = sprintf('git checkout tmp_%s', $targetBranch);
 
         # perform the merge
         $commands[] = sprintf('git merge pr_%d --no-ff -m "%s"', $pullRequest, $message);


### PR DESCRIPTION
With the new option --branch you can now define the target branch.

Also all new merges are rebased ahead of the merge.

Tickets:
- none